### PR TITLE
Cambia la clase serial a Unbufferedserial

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -14,7 +14,7 @@
 #define LEDG_PERIOD         7       
 #define LEDB_PERIOD         11      
 // Objeto para establecer la comunicación serial con el Pc
-BufferedSerial serial(USBTX, USBRX, 9600);
+UnbufferedSerial serial(USBTX, USBRX, 9600);
 using namespace std;
 
 


### PR DESCRIPTION
Este cambio permite recibir datos por consola mediante cin de iostream (C++). La clase Unbufferedserial crea el objeto de comunicación sin disponer de un buffer intermedio para almacenar bytes para transmitir y recibir a nivel de hardware.  En este caso, la aplicación de usuario es la encargada de transmitir y recibir la información, tal como se diseña originalmente el código propuesto. 